### PR TITLE
docs: add troubleshooting section for SIGBUS fix in v0.2.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ unsafe {
 
 If you encounter `MDBX_MAP_FULL` (-30797), increase `size_upper` before opening.
 
+## Troubleshooting
+
+### SIGBUS on Large Databases (1TB+)
+
+**Fixed in v0.2.21**. Earlier versions could crash with SIGBUS when writing to large databases because tree splits can allocate 1000+ pages at once. If the file wasn't pre-extended, writes to mmap'd regions beyond EOF caused SIGBUS.
+
+**Solution**: Upgrade to v0.2.21 or later.
+
+**What changed:**
+1. Pager now uses `geometry.size_upper` for the mmap virtual address range
+2. File is extended at `env_open` if `metadata.size_now > file_size`
+3. Before allocating pages, file is pre-extended by `growth_step` (default 16MB)
+
+### MDBX_CORRUPTED (-30796)
+
+If your database was corrupted by previous SIGBUS crashes, you'll need to restore from backup or resync from scratch.
+
 ## Supported Platforms
 
 | Platform | Artifact |


### PR DESCRIPTION
## Summary

Add troubleshooting documentation for the SIGBUS fix released in v0.2.21.

### Changes

- Add Troubleshooting section to README.md
- Document SIGBUS issue on large (1TB+) databases
- Explain the root cause: tree splits can allocate 1000+ pages, file wasn't pre-extended
- Document the fix: pre-extend file by growth_step before page allocation
- Add note about MDBX_CORRUPTED for databases corrupted by prior crashes

### Related

- Fixes documentation for Issue #8
- See full changelog in mdbx-rs repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a README Troubleshooting section describing the SIGBUS fix in v0.2.21 for large databases and guidance for MDBX_CORRUPTED recovery.
> 
> - **Docs (README)**:
>   - **Troubleshooting**:
>     - Add guidance on SIGBUS crashes for large (1TB+) databases, noting fix in `v0.2.21` and recommending upgrade.
>     - Outline implementation changes: use `geometry.size_upper` for mmap range, extend file at `env_open` when needed, and pre-extend by `growth_step` before page allocation.
>     - Add note on handling `MDBX_CORRUPTED` (-30796): restore from backup or resync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34fe5e543b69c61d0eeab25a210547eb62e5c9c2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->